### PR TITLE
feature/docs: add endpoint GET to list analyses for patient and docum…

### DIFF
--- a/src/routes/analysisRoutes.ts
+++ b/src/routes/analysisRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createAnalysis } from '../controllers/analysisController.js';
+import { createAnalysis, getPatientAnalyses } from '../controllers/analysisController.js';
 
 const router = Router();
 
@@ -80,6 +80,50 @@ const router = Router();
  *               $ref: '#/components/schemas/ErrorMessage'
  */
 router.post('/analysis', createAnalysis);
+
+/**
+ * @swagger
+ * /patients/{id}/analyses:
+ *   get:
+ *     tags:
+ *       - Analysis
+ *     summary: Retorna o histórico de análises de um paciente
+ *     description: Retorna todas as análises realizadas para o paciente especificado, ordenadas por data de criação (mais recentes primeiro).
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do paciente
+ *     responses:
+ *       200:
+ *         description: Lista de análises retornada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   insights:
+ *                     type: object
+ *                   riskLevel:
+ *                     type: string
+ *                   alert:
+ *                     type: string
+ *                     nullable: true
+ *                   createdAt:
+ *                     type: string
+ *                     format: date-time
+ *                   createdBy:
+ *                     type: string
+ *       404:
+ *         description: Paciente não encontrado
+ */
+router.get('/patients/:id/analyses', getPatientAnalyses);
 
 export default router;
 


### PR DESCRIPTION

This pull request adds a new endpoint to retrieve the history of analyses for a specific patient. The main changes include implementing the controller logic to fetch analyses, updating the routes, and documenting the new endpoint with Swagger.

**New endpoint for patient analysis history:**

* Added the `getPatientAnalyses` controller in `analysisController.ts` to fetch all analyses for a given patient, ordered by creation date, with error handling for missing patients and server errors.
* Registered the new route `/patients/:id/analyses` in `analysisRoutes.ts`, connecting it to the `getPatientAnalyses` controller.

**API documentation:**

* Added Swagger documentation for the new endpoint, detailing parameters, response schema, and possible status codes.